### PR TITLE
Removed unused import of random search.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 // the file to build the command line interface
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import {displaySearchHistory, cookRecipe, randomRecipe} from './app.js';
+import {displaySearchHistory, cookRecipe} from './app.js';
 
 yargs(hideBin(process.argv))
     // $0 expands the file name
@@ -43,17 +43,6 @@ yargs(hideBin(process.argv))
             else{
                 cookRecipe('id', args.variable);
             }
-        }
-    ).command(
-        // command name with argument
-        'random',
-        // description
-        'get a random meal recipe',
-        // builder function to add a positional argument and option
-        () => {},
-        // handler function
-        () => {
-            randomRecipe();
         }
     ).command(
         'history',


### PR DESCRIPTION
This small PR removes the leftover import of randomSearch formerly in `api.js` and its leftover usage as a dud command.